### PR TITLE
fix constructor ordering

### DIFF
--- a/FFT3DFilter.cpp
+++ b/FFT3DFilter.cpp
@@ -193,12 +193,13 @@ kratio(_kratio), sharpen(_sharpen), scutoff(_scutoff), svr(_svr), smin(_smin), s
 measure(_measure), interlaced(_interlaced), wintype(_wintype),
 pframe(_pframe), px(_px), py(_py), pshow(_pshow), pcutoff(_pcutoff), pfactor(_pfactor),
 sigma2(_sigma2), sigma3(_sigma3), sigma4(_sigma4), degrid(_degrid),
-dehalo(_dehalo), hr(_hr), ht(_ht), ncpu(_ncpu),
-vi(_vi), node(_node), wsharpen(nullptr, nullptr), wdehalo(nullptr, nullptr),
-pattern2d(nullptr, nullptr), pattern3d(nullptr, nullptr), in(nullptr, nullptr),
-gridsample(nullptr, nullptr), outLast(nullptr, nullptr), covar(nullptr, nullptr),
-covarProcess(nullptr, nullptr), outrez(nullptr, nullptr), plan(nullptr, nullptr), planinv(nullptr, nullptr),
-plan1(nullptr, nullptr) {
+dehalo(_dehalo), hr(_hr), ht(_ht), ncpu(_ncpu), in(nullptr, nullptr),
+outrez(nullptr, nullptr), gridsample(nullptr, nullptr), plan(nullptr, nullptr),
+planinv(nullptr, nullptr), plan1(nullptr, nullptr),
+wsharpen(nullptr, nullptr), wdehalo(nullptr, nullptr),
+outLast(nullptr, nullptr), covar(nullptr, nullptr),
+covarProcess(nullptr, nullptr), pattern2d(nullptr, nullptr),
+pattern3d(nullptr, nullptr), vi(_vi), node(_node) {
     int istat = fftwf_init_threads();
     if (istat == 0)
         throw std::runtime_error{ "fftwf_init_threads() failed!" };


### PR DESCRIPTION
```
In file included from ../FFT3DFilter.cpp:36:
../FFT3DFilter.h: In constructor ‘FFT3DFilter::FFT3DFilter(float, float, int, int, int, int, int, int, float, float, float, float, float, float, bool, bool, int, int, int, int, bool, float, float, float, float, float, float, float, float, float, int, VSVideoInfo, VSNodeRef*)’:
../FFT3DFilter.h:197:17: warning: ‘FFT3DFilter::node’ will be initialized after [-Wreorder]
  197 |     VSNodeRef  *node;
      |                 ^~~~
In file included from ../FFT3DFilter.cpp:36:
../FFT3DFilter.h:96:52: warning:   ‘std::unique_ptr<float [], void (*)(void*)> FFT3DFilter::wsharpen’ [-Wreorder]
   96 |     std::unique_ptr<float[], decltype(&fftw_free)> wsharpen;
      |                                                    ^~~~~~~~
../FFT3DFilter.cpp:181:1: warning:   when initialized here [-Wreorder]
  181 | FFT3DFilter::FFT3DFilter
      | ^~~~~~~~~~~
In file included from ../FFT3DFilter.cpp:36:
../FFT3DFilter.h:129:52: warning: ‘FFT3DFilter::pattern3d’ will be initialized after [-Wreorder]
  129 |     std::unique_ptr<float[], decltype(&fftw_free)> pattern3d;
      |                                                    ^~~~~~~~~
In file included from ../FFT3DFilter.cpp:36:
../FFT3DFilter.h:68:52: warning:   ‘std::unique_ptr<float [], void (*)(void*)> FFT3DFilter::in’ [-Wreorder]
   68 |     std::unique_ptr<float[], decltype(&fftw_free)> in;
      |                                                    ^~
../FFT3DFilter.cpp:181:1: warning:   when initialized here [-Wreorder]
  181 | FFT3DFilter::FFT3DFilter
      | ^~~~~~~~~~~
In file included from ../FFT3DFilter.cpp:36:
../FFT3DFilter.h:104:60: warning: ‘FFT3DFilter::covarProcess’ will be initialized after [-Wreorder]
  104 |     std::unique_ptr<fftwf_complex[], decltype(&fftw_free)> covarProcess;
      |                                                            ^~~~~~~~~~~~
../FFT3DFilter.h:69:60: warning:   ‘std::unique_ptr<float [][2], void (*)(void*)> FFT3DFilter::outrez’ [-Wreorder]
   69 |     std::unique_ptr<fftwf_complex[], decltype(&fftw_free)> outrez;
      |                                                            ^~~~~~
../FFT3DFilter.cpp:181:1: warning:   when initialized here [-Wreorder]
  181 | FFT3DFilter::FFT3DFilter
      | ^~~~~~~~~~~
```